### PR TITLE
Use `pin_compatible` with `cuda-*` packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: 3ed4d6ce76dd6cc03280cedbee536452d3c45c5e371984146760f55f6290fbd7
 
 build:
-  number: 1
+  number: 2
   {% if not (environ.get("cuda_compiler_version")|string()).startswith(major_version|string()) %}
   skip: true
   {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,9 @@ requirements:
     - cython                              # [build_platform != target_platform]
   host:
     - cuda-cudart-dev
+    - cuda-cudart
     - cuda-nvrtc-dev
+    - cuda-nvrtc
     - cuda-profiler-api
     - cython
     - pip
@@ -64,7 +66,7 @@ requirements:
     - python
     # cuda-python requires cuda-nvrtc from the same major version. We ignored
     # run-exports of cuda-nvrtc-dev and instead allow a looser pinning here.
-    - cuda-nvrtc >={{ major_version }},<{{ major_version+1 }}.0a0
+    - {{ pin_compatible('cuda-nvrtc', min_pin='x', max_pin='x') }}
     - {{ pin_compatible('cuda-version', min_pin='x', max_pin='x') }}
     - pywin32  # [win]
   run_constrained:
@@ -72,7 +74,7 @@ requirements:
     # cudart. This package is optionally dlopen'd for getting the local cudart
     # version with cuda.cudart.getLocalRuntimeVersion(). We ignored run-exports
     # of cuda-cudart-dev and instead allow a looser pinning here.
-    - cuda-cudart >={{ major_version }},<{{ major_version+1 }}.0a0
+    - {{ pin_compatible('cuda-cudart', min_pin='x', max_pin='x') }}
 
 test:
   imports:


### PR DESCRIPTION
Update pinnings of `cuda-*` packages to rely on `pin_compatible`.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
