### PR TITLE
Drop `BUILD_PREFIX` headers from Windows `INCLUDE` path

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ build:
   skip: true
   {% endif %}
   script:
-    - set "INCLUDE=%INCLUDE%;%BUILD_PREFIX%\Library\include"  # [win64]
     - {{ PYTHON }} setup.py build_ext --inplace -j1
     - {{ PYTHON }} -m pip install . --no-deps -vv
   script_env:
@@ -36,6 +35,7 @@ build:
     # The run-exports from these dev packages are too tight, so we ignore them.
     # The cuda-python package supports CUDA Enhanced Compatibility through its
     # use of dlopen, so it is compatible with other CUDA minor versions.
+    - cuda-crt-dev_{{ target_platform }}
     - cuda-cudart-dev
     - cuda-nvrtc-dev
 
@@ -50,6 +50,7 @@ requirements:
     - python                              # [build_platform != target_platform]
     - cython                              # [build_platform != target_platform]
   host:
+    - cuda-crt-dev_{{ target_platform }}
     - cuda-cudart-dev
     - cuda-cudart
     - cuda-nvrtc-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ build:
   skip: true
   {% endif %}
   script:
-    - {{ PYTHON }} setup.py build_ext --inplace -j1
     - {{ PYTHON }} -m pip install . --no-deps -vv
   script_env:
     # Ensure that CUDA includes can be found by the host compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: ba983dbb91a7f51553315fe14f1fbcbb4920f8f2e9bb47620735d2d63c33e673
 
 build:
-  number: 0
+  number: 1
   {% if not (environ.get("cuda_compiler_version")|string()).startswith(major_version|string()) %}
   skip: true
   {% endif %}


### PR DESCRIPTION
Partially address issue ( https://github.com/conda-forge/cuda-python-feedstock/issues/74 )

Drop Windows workaround adding headers from the `build` environment to the include path. Do this by depending on `cuda-crt*` headers in `requirements/host`

Also drop call to `setup.py` directly (re-enabling parallel builds as well)

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
