### PR TITLE
MNT: remove cpcloud from recipe maintainers

### DIFF
--- a/.recipe_maintainers.json
+++ b/.recipe_maintainers.json
@@ -1,6 +1,5 @@
 {
   "bdice": 3943761,
-  "cpcloud": 417981,
   "jakirkham": 3019665,
   "kkraus14": 3665167,
   "leofang": 5534781,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -205,7 +205,6 @@ extra:
   recipe-maintainers:
     - rwgk
     - rparolin
-    - cpcloud
     - bdice
     - jakirkham
     - leofang


### PR DESCRIPTION
Removes `cpcloud` from the `cuda-python` recipe maintainers.

Drops the handle from `recipe/meta.yaml` (`extra.recipe-maintainers`) and the corresponding entry in the generated `.recipe_maintainers.json` to keep the two in sync. Plenty of maintainers remain.

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (n/a — maintainer-only change, no package rebuild required)
- [x] Re-rendered with the latest conda-smithy (n/a — only the maintainer list changed)
- [x] Ensured the license file is being packaged (n/a)